### PR TITLE
Push Fuse Activation optimization flow after Lowering and Quantization

### DIFF
--- a/src/aie4ml/aie_backend.py
+++ b/src/aie4ml/aie_backend.py
@@ -52,10 +52,10 @@ class AIEBackend(Backend):
     def _register_flows(self):
         initializers = self._get_layer_initializers()
         init_flow = register_flow('init_layers', initializers, requires=['optimize'], backend=self.name)
-        lower_flow = register_flow('lower', ['aie:lower_to_aie_ir'], requires=[fuse_flow], backend=self.name)
+        lower_flow = register_flow('lower', ['aie:lower_to_aie_ir'], requires=[init_flow], backend=self.name)
         quant_flow = register_flow('quantize', ['aie:integer_quantizer'], requires=[lower_flow], backend=self.name)
-        fuse_flow = register_flow('fuse', ['aie:fuse_activation_casts'], requires=[init_flow], backend=self.name)
-        resolve_flow = register_flow('resolve', ['aie:resolve'], requires=[quant_flow], backend=self.name)
+        fuse_flow = register_flow('fuse', ['aie:fuse_activation_casts'], requires=[quant_flow], backend=self.name)
+        resolve_flow = register_flow('resolve', ['aie:resolve'], requires=[fuse_flow], backend=self.name)
         pack_flow = register_flow('pack', ['aie:pack_kernel_artifacts'], requires=[resolve_flow], backend=self.name)
         placement_flow = register_flow('placement', ['aie:place_kernels'], requires=[pack_flow], backend=self.name)
         memory_plan_flow = register_flow(

--- a/src/aie4ml/aie_backend.py
+++ b/src/aie4ml/aie_backend.py
@@ -52,9 +52,9 @@ class AIEBackend(Backend):
     def _register_flows(self):
         initializers = self._get_layer_initializers()
         init_flow = register_flow('init_layers', initializers, requires=['optimize'], backend=self.name)
-        fuse_flow = register_flow('fuse', ['aie:fuse_activation_casts'], requires=[init_flow], backend=self.name)
         lower_flow = register_flow('lower', ['aie:lower_to_aie_ir'], requires=[fuse_flow], backend=self.name)
         quant_flow = register_flow('quantize', ['aie:integer_quantizer'], requires=[lower_flow], backend=self.name)
+        fuse_flow = register_flow('fuse', ['aie:fuse_activation_casts'], requires=[init_flow], backend=self.name)
         resolve_flow = register_flow('resolve', ['aie:resolve'], requires=[quant_flow], backend=self.name)
         pack_flow = register_flow('pack', ['aie:pack_kernel_artifacts'], requires=[resolve_flow], backend=self.name)
         placement_flow = register_flow('placement', ['aie:place_kernels'], requires=[pack_flow], backend=self.name)

--- a/src/aie4ml/passes/fuse_activation.py
+++ b/src/aie4ml/passes/fuse_activation.py
@@ -21,12 +21,15 @@ class FuseActivationCasts(ModelOptimizerPass):
             return False
 
         prev_node = node.inputs[0].producer
-        if prev_node is None or \
-            (getattr(prev_node, 'op_type', None) != 'dense' and \
-             getattr(prev_node, 'op_type', None) != 'input'):
+        if prev_node is None:
             return False
-
-        return True
+        match getattr(prev_node, 'op_type', None):
+            case 'dense':
+                return True
+            case 'input':
+                return act == 'linear'
+            case _:
+                return False
     
     def transform(self, model) -> bool:
         ctx = get_backend_context(model)

--- a/src/aie4ml/passes/fuse_activation.py
+++ b/src/aie4ml/passes/fuse_activation.py
@@ -1,12 +1,15 @@
 # Dense + Activation fusion pass for the AIE backend.
 
 from hls4ml.model.optimizer import OptimizerPass
+from ..ir import get_backend_context, LogicalIR, TraitInstance
 
 
 class FuseActivationCasts(OptimizerPass):
     """Fuse Dense+Activation pairs (relu or linear) directly in the hls4ml graph."""
 
     _SUPPORTED = {'relu', 'linear'}
+
+    ## TO DO: FIX  MATCH FOR NEW CASE
 
     def match(self, node):
         if getattr(node, 'class_name', None) != 'Activation' or len(node.inputs) != 1:
@@ -21,8 +24,45 @@ class FuseActivationCasts(OptimizerPass):
             return False
 
         return True
-
+    
     def transform(self, model, node):
+        ctx = get_backend_context(model)
+        graph: LogicalIR = ctx.ir.logical
+
+        for n in graph.nodes:
+            if n.name == node.name + '_aie':
+                node = n
+                break
+
+        input_node = node.inputs[0].producer
+        activation = (node.get_attr('activation', '') or '').lower()
+        input_node.add_trait(TraitInstance('fused_activation', {'activation': activation}))
+
+        act_quant = node.metadata.setdefault('quant', {})
+        input_quant = input_node.metadata.setdefault('quant', {})
+        if not act_quant:
+            raise RuntimeError('Quantization information missing. Run quant before invoking downstream passes.')
+        input_quant['output_precision'] = act_quant['output_precision']
+        
+        graph.remove_node(node)
+
+        return True
+    
+    def _old_match(self, node):
+        if getattr(node, 'class_name', None) != 'Activation' or len(node.inputs) != 1:
+            return False
+
+        act = (node.get_attr('activation', '') or '').lower()
+        if act not in self._SUPPORTED:
+            return False
+
+        prev_node = node.get_input_node()
+        if prev_node is None or getattr(prev_node, 'class_name', None) != 'Dense':
+            return False
+
+        return True
+
+    def _old_transform(self, model, node):
         dense = node.get_input_node()
         activation = (node.get_attr('activation', '') or '').lower()
 

--- a/src/aie4ml/passes/fuse_activation.py
+++ b/src/aie4ml/passes/fuse_activation.py
@@ -1,50 +1,50 @@
 # Dense + Activation fusion pass for the AIE backend.
 
-from hls4ml.model.optimizer import OptimizerPass
+from hls4ml.model.optimizer.optimizer import ModelOptimizerPass
 from ..ir import get_backend_context, LogicalIR, TraitInstance
 
 
-class FuseActivationCasts(OptimizerPass):
+class FuseActivationCasts(ModelOptimizerPass):
     """Fuse Dense+Activation pairs (relu or linear) directly in the hls4ml graph."""
 
     _SUPPORTED = {'relu', 'linear'}
 
+    def __init__(self):
+        self.name = 'fuse_activation_casts'
+
     ## TO DO: FIX  MATCH FOR NEW CASE
 
     def match(self, node):
-        if getattr(node, 'class_name', None) != 'Activation' or len(node.inputs) != 1:
+        if getattr(node, 'op_type', None) != 'activation' or len(node.inputs) != 1:
             return False
 
-        act = (node.get_attr('activation', '') or '').lower()
+        act = (node.metadata.get('activation', '')).lower()
         if act not in self._SUPPORTED:
             return False
 
-        prev_node = node.get_input_node()
-        if prev_node is None or getattr(prev_node, 'class_name', None) != 'Dense':
+        prev_node = node.inputs[0].producer
+        if prev_node is None or getattr(prev_node, 'op_type', None) != 'dense':
             return False
 
         return True
     
-    def transform(self, model, node):
+    def transform(self, model) -> bool:
         ctx = get_backend_context(model)
         graph: LogicalIR = ctx.ir.logical
 
-        for n in graph.nodes:
-            if n.name == node.name + '_aie':
-                node = n
-                break
+        for node in graph.nodes:
+            if self.match(node):
+                prev_node = node.inputs[0].producer
+                activation = node.metadata.get('activation', '').lower()
+                prev_node.add_trait(TraitInstance('fused_activation', {'activation': activation}))
 
-        input_node = node.inputs[0].producer
-        activation = (node.get_attr('activation', '') or '').lower()
-        input_node.add_trait(TraitInstance('fused_activation', {'activation': activation}))
+                act_quant = node.metadata.get('quant', {})
+                prev_quant = prev_node.metadata.get('quant', {})
+                if not act_quant:
+                    raise RuntimeError('Quantization information missing. Run quant before invoking downstream passes.')
+                prev_quant['output_precision'] = act_quant['output_precision']
 
-        act_quant = node.metadata.setdefault('quant', {})
-        input_quant = input_node.metadata.setdefault('quant', {})
-        if not act_quant:
-            raise RuntimeError('Quantization information missing. Run quant before invoking downstream passes.')
-        input_quant['output_precision'] = act_quant['output_precision']
-        
-        graph.remove_node(node)
+                graph.remove_node(node)
 
         return True
     

--- a/src/aie4ml/passes/fuse_activation.py
+++ b/src/aie4ml/passes/fuse_activation.py
@@ -12,8 +12,6 @@ class FuseActivationCasts(ModelOptimizerPass):
     def __init__(self):
         self.name = 'fuse_activation_casts'
 
-    ## TO DO: FIX  MATCH FOR NEW CASE
-
     def match(self, node):
         if getattr(node, 'op_type', None) != 'activation' or len(node.inputs) != 1:
             return False
@@ -23,7 +21,9 @@ class FuseActivationCasts(ModelOptimizerPass):
             return False
 
         prev_node = node.inputs[0].producer
-        if prev_node is None or getattr(prev_node, 'op_type', None) != 'dense':
+        if prev_node is None or \
+            (getattr(prev_node, 'op_type', None) != 'dense' and \
+             getattr(prev_node, 'op_type', None) != 'input'):
             return False
 
         return True
@@ -32,7 +32,8 @@ class FuseActivationCasts(ModelOptimizerPass):
         ctx = get_backend_context(model)
         graph: LogicalIR = ctx.ir.logical
 
-        for node in graph.nodes:
+        for i in range(len(graph.nodes) - 1, -1, -1):
+            node = graph.nodes[i]
             if self.match(node):
                 prev_node = node.inputs[0].producer
                 activation = node.metadata.get('activation', '').lower()
@@ -46,30 +47,4 @@ class FuseActivationCasts(ModelOptimizerPass):
 
                 graph.remove_node(node)
 
-        return True
-    
-    def _old_match(self, node):
-        if getattr(node, 'class_name', None) != 'Activation' or len(node.inputs) != 1:
-            return False
-
-        act = (node.get_attr('activation', '') or '').lower()
-        if act not in self._SUPPORTED:
-            return False
-
-        prev_node = node.get_input_node()
-        if prev_node is None or getattr(prev_node, 'class_name', None) != 'Dense':
-            return False
-
-        return True
-
-    def _old_transform(self, model, node):
-        dense = node.get_input_node()
-        activation = (node.get_attr('activation', '') or '').lower()
-
-        in_var = node.get_input_variable()
-        out_var = node.get_output_variable()
-        in_var.type.precision = out_var.type.precision
-
-        dense.set_attr('aie_fused_activation', activation)
-        model.remove_node(node)
         return True

--- a/src/aie4ml/passes/lower.py
+++ b/src/aie4ml/passes/lower.py
@@ -28,6 +28,9 @@ class LowerToAieIr(ModelOptimizerPass):
     def __init__(self):
         self.name = 'lower_to_aie_ir'
 
+
+    # TO DO: ADD SUPPORT FOR ACTIVATION NODE
+
     def transform(self, model) -> bool:
         ctx = ensure_backend_context(model, lambda: self._create_context(model))
         ctx.reset_ir()

--- a/src/aie4ml/passes/lower.py
+++ b/src/aie4ml/passes/lower.py
@@ -28,9 +28,6 @@ class LowerToAieIr(ModelOptimizerPass):
     def __init__(self):
         self.name = 'lower_to_aie_ir'
 
-
-    # TO DO: ADD SUPPORT FOR ACTIVATION NODE
-
     def transform(self, model) -> bool:
         ctx = ensure_backend_context(model, lambda: self._create_context(model))
         ctx.reset_ir()
@@ -48,8 +45,6 @@ class LowerToAieIr(ModelOptimizerPass):
         created_nodes = set()
 
         for layer in layers:
-            if layer.class_name == 'Activation' and self._is_identity_activation(layer):
-                continue
 
             node = OpNode(
                 name=f'{layer.name}_aie',
@@ -149,7 +144,3 @@ class LowerToAieIr(ModelOptimizerPass):
             fused = (layer.get_attr('aie_fused_activation', '') or '').lower()
             if fused:
                 node.add_trait(TraitInstance('fused_activation', {'activation': fused}))
-
-    def _is_identity_activation(self, layer) -> bool:
-        act = (layer.get_attr('activation', '') or '').lower()
-        return act in ('', 'linear', 'identity')

--- a/src/aie4ml/passes/quant.py
+++ b/src/aie4ml/passes/quant.py
@@ -193,7 +193,6 @@ class IntegerQuantizer(ModelOptimizerPass):
                 continue
 
             source_layer_name = node.metadata.get('source_layer')
-            print("Processing IR node:", node.name, "of type:", node.op_type, "from source layer:", source_layer_name)
             layer = lookup_layer(model, source_layer_name)
             if layer is None:
                 log.warning('Unable to locate source layer "%s" for IR node %s.', source_layer_name, node.name)
@@ -268,14 +267,9 @@ class IntegerQuantizer(ModelOptimizerPass):
             quant_metadata['bias_precision'] = bias_intent
         quant_metadata['output_precision'] = output_intent
 
-        print(f"Quantization info for layer {layer.name}: {quant_metadata}")
-
         return True
 
     def _quantize_activation_node(self, model, ctx, node, layer) -> bool:
-
-        print("Running activation quantization for layer:", layer.name)
-
         input_var = layer.get_input_variable()
         output_var = layer.get_output_variable()
         input_precision = getattr(input_var.type, 'precision', None)
@@ -289,7 +283,5 @@ class IntegerQuantizer(ModelOptimizerPass):
         quant_metadata = node.metadata.setdefault('quant', {})
         quant_metadata['input_precision'] = input_intent
         quant_metadata['output_precision'] = output_intent
-
-        print(f"Quantization info for layer {layer.name}: {quant_metadata}")
 
         return True


### PR DESCRIPTION
# Description

Changed the order of the optimization flows, pushing the activation functions fusion after the lowering and quantization. This way, the `fuse_activation_casts` flow is independent from the front-end used.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Tests

No proper test present, but correctness was checked on tutorial 1 (both x86 and hardware simulation).

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
