### PR TITLE
fix(aie4ml_report): Drop the self-edges that result from a cascade op

### DIFF
--- a/src/aie4ml/report.py
+++ b/src/aie4ml/report.py
@@ -252,7 +252,9 @@ def _op_edges(vitis: Dict[str, Any]) -> List[tuple]:
                 continue
             seen.add(node)
             if node in inst_op:
-                edges.add((inst_op[src], inst_op[node]))
+                # Skip self-edges: Drop the self-edges that result from a cascaded op's tiles
+                if inst_op[src] != inst_op[node]:
+                    edges.add((inst_op[src], inst_op[node]))
             else:
                 stack.extend(succ.get(node, []))
     return sorted(edges)


### PR DESCRIPTION
Root cause: a cascaded op (cas_length > 1) spreads across multiple tiles that all map to the same op name, so the cascade net between them produced a self-edge (dense_0_aie, dense_0_aie) in _op_edges. That self-edge made _critical_path set came['dense_0_aie'] = 'dense_0_aie', and its chain reconstruction loop then followed that pointer X → X → X … forever, growing a list until memory ran out.